### PR TITLE
Alternative breaker (else-if)

### DIFF
--- a/ex/04.mg
+++ b/ex/04.mg
@@ -1,8 +1,12 @@
-add check():
+[serializable]
+def check():
     if a && b || c && d:
-        x = x +- 1
+        x = x + 1
         z = 1
+    else-if a.is_defined:
+        $return a           #[macro return ^a]
     else:
-        $pass
+        $pass               #[macro pass]
     endif
-endadd
+enddef
+

--- a/ex/05.mg
+++ b/ex/05.mg
@@ -1,9 +1,9 @@
 foo
     if x:
         1
-    else-if y:
+    else-if y then:
         2
     else:
-        2
+        3
     endif
 endfoo

--- a/ex/05.mg
+++ b/ex/05.mg
@@ -1,6 +1,8 @@
 foo
     if x:
         1
+    else-if y:
+        2
     else:
         2
     endif

--- a/ex/07.mg
+++ b/ex/07.mg
@@ -1,0 +1,14 @@
+{
+    "glossary" => {
+        "title" => "example glossary",
+		"GlossDiv" => {
+            "title" => "S",
+			"GlossList" => {
+                "GlossEntry" => {
+                    "ID" => "SGML",
+					"SortAs" => "SGML"
+                }
+            }
+        }
+    }
+}

--- a/ex/08.mg
+++ b/ex/08.mg
@@ -1,0 +1,4 @@
+block
+    $return x
+    return
+endblock

--- a/poplog/load.p
+++ b/poplog/load.p
@@ -5,7 +5,11 @@ extend_searchlist( 'lib', popuseslist ) -> popuseslist;
 
 load monogram.p
 
+
+/*
 lvars f;
 for f in ['01' '02' '03' '04' '05' '06'] do
+    npr( f );
     monogram(discin('../ex/' >< f >< '.mg')) ==>
 endfor;
+*/

--- a/poplog/monogram.p
+++ b/poplog/monogram.p
@@ -196,6 +196,9 @@ define read_form_expr(opening_word);
                     ;;; Skip the `-` `if`
                     lvars (t1, t2) = proglist.tl.dest.dest -> proglist;
                     lvars kw = consword( item1 >< t1 >< t2 );
+                    if t2 /== opening_word then
+                        mishap( 'Mismatched breaker found', [FOUND ^kw INSIDE ^opening_word])
+                    endif;
                     [part ^current_keyword ^^current_part];
                     [] -> current_part;
                     kw -> current_keyword;


### PR DESCRIPTION
As an alternative to `WORD`:  being a breaker, we also want `WORD1-WORD2` to be an alternative breaker. WORD2 has to be the same as the enclosing keyword or it is a syntax error.

In addition the alternative breaker re-establishes the ungluing-context so that the next `WORD:` can be abbreviated to `:`.