### PR TITLE
Fix docker image with --test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk update && apk add --no-cache curl
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sh -s -- --to /usr/local/bin
 
 # Run the Justfile recipe to build the monogram executable
-RUN just build
+RUN just build-for-docker
 
 # ----------
 # Runtime stage
@@ -27,6 +27,9 @@ COPY --from=builder /go/monogram/monogram /app/monogram
 
 # Ensure the binary is executable
 RUN chmod +x /app/monogram
+
+# Expose the port that the --test flag uses when running in a container.
+EXPOSE 8080
 
 # Set entrypoint to allow arguments to pass through
 ENTRYPOINT ["/app/monogram"]

--- a/Justfile
+++ b/Justfile
@@ -25,6 +25,9 @@ install: build
 build:
     just -f go/monogram/Justfile build
 
+build-for-docker:
+    just -f go/monogram/Justfile build-for-docker
+
 test: unittest functest
 
 functest:

--- a/go/monogram/Justfile
+++ b/go/monogram/Justfile
@@ -19,6 +19,10 @@ install:
 # Alias: build both full and mini executables
 build: build-full build-mini
 
+build-for-docker:
+    # Build the full executable with the web server enabled but flagged for docker
+    go build -tags withweb -ldflags="-X 'main.IsBuiltForDocker=true'" -o monogram ./cmd/monogram
+
 # Build the full executable with the web server enabled
 build-full:
     go build -tags withweb -o monogram ./cmd/monogram

--- a/go/monogram/cmd/monogram/main.go
+++ b/go/monogram/cmd/monogram/main.go
@@ -39,6 +39,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// Controlled by ldflags.
+var IsBuiltForDocker = "false"
+
 type FormatOptions struct {
 	Format       string
 	Input        string
@@ -70,7 +73,7 @@ func setupFlags(fs *pflag.FlagSet, options *FormatOptions, optionsFile *string, 
 	if showVersion != nil {
 		fs.BoolVar(showVersion, "version", false, "Display the version information")
 	}
-	if withWeb() {
+	if WithWeb {
 		if openBrowserFlag != nil {
 			fs.BoolVar(openBrowserFlag, "open-browser", true, "Specify whether --test automatically opens a browser")
 		}
@@ -132,7 +135,6 @@ func parseToAST(input string, foptions *FormatOptions) (*lib.Node, error) {
 }
 
 func main() {
-
 	// Initialize the options struct
 	options := FormatOptions{
 		Format:       "",

--- a/go/monogram/cmd/monogram/noserver.go
+++ b/go/monogram/cmd/monogram/noserver.go
@@ -3,9 +3,8 @@
 
 package main
 
-func withWeb() bool {
-	return false
-}
+// Controlled by a build tag (withweb) to include or exclude web server functionality.
+var WithWeb bool = false
 
 // startTestServer starts an HTTP listener on the specified port and opens the browser.
 func startTestServer(port string, _ bool, options *FormatOptions) {

--- a/go/monogram/cmd/monogram/server.go
+++ b/go/monogram/cmd/monogram/server.go
@@ -233,10 +233,8 @@ func startTestServer(port string, openBrowserFlag bool, options *FormatOptions) 
 		host = "0.0.0.0"
 	}
 	addr := host + ":" + port
-	fmt.Println("IsBuiltForDocker:", IsBuiltForDocker)
-
 	if IsBuiltForDocker == "true" || !openBrowserFlag {
-		log.Println("Open a browser and navigate to ", "http://"+addr)
+		log.Println("Listening. Open a browser on http://localhost:PORT, using the specified port.")
 	} else {
 		log.Printf("Opening a browser on %s...", addr)
 		go openBrowser("http://" + addr)

--- a/go/monogram/cmd/monogram/server.go
+++ b/go/monogram/cmd/monogram/server.go
@@ -8,7 +8,6 @@ import (
 	"html/template"
 	"log"
 	"net/http"
-	"os"
 
 	"bytes"
 	"fmt"
@@ -18,9 +17,8 @@ import (
 	"strings"
 )
 
-func withWeb() bool {
-	return true
-}
+// Controlled by a build tag, withweb, to include or exclude web server functionality.
+var WithWeb bool = true
 
 var formTemplate = template.Must(template.New("form").Parse(`
 <!DOCTYPE html>
@@ -220,18 +218,24 @@ var formTemplate = template.Must(template.New("form").Parse(`
 </html>
 `))
 
-// startTestServer starts an HTTP listener on the specified port and opens the browser.
+// startTestServer initializes an HTTP server on the specified port.
+// It adjusts the bind address depending on whether it's running inside a container.
 func startTestServer(port string, openBrowserFlag bool, options *FormatOptions) {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		indexHandler(w, r, options)
 	})
 	http.HandleFunc("/translate", translateHandler)
 
-	if port == "" {
-		port = "3000"
+	// Default to localhost for normal execution.
+	// When running inside a container, bind to 0.0.0.0 so the server is accessible externally.
+	host := "localhost"
+	if IsBuiltForDocker == "true" {
+		host = "0.0.0.0"
 	}
-	addr := "localhost:" + port
-	if isRunningInDocker() || !openBrowserFlag {
+	addr := host + ":" + port
+	fmt.Println("IsBuiltForDocker:", IsBuiltForDocker)
+
+	if IsBuiltForDocker == "true" || !openBrowserFlag {
 		log.Println("Open a browser and navigate to ", "http://"+addr)
 	} else {
 		log.Printf("Opening a browser on %s...", addr)
@@ -240,11 +244,6 @@ func startTestServer(port string, openBrowserFlag bool, options *FormatOptions) 
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatalf("Failed to start test server: %v", err)
 	}
-}
-
-func isRunningInDocker() bool {
-	_, err := os.Stat("/.dockerenv")
-	return err == nil
 }
 
 func indexHandler(w http.ResponseWriter, _ *http.Request, options *FormatOptions) {


### PR DESCRIPTION
Running the container image --test wasn't working because the monogram test server binds to localhost, which won;t serve externally. This PR fixes it for a specific container-built version of monogram.